### PR TITLE
Fix Database Logsink API Response Parsing and TLS Field Marshaling

### DIFF
--- a/databases_test.go
+++ b/databases_test.go
@@ -4093,12 +4093,14 @@ func TestDatabases_CreateLogsink(t *testing.T) {
 	}
 
 	body := `{
-        "sink_id":"deadbeef-dead-4aa5-beef-deadbeef347d",
-        "sink_name": "logs-sink",
-        "sink_type": "opensearch",
-        "config": {
-          "url": "https://user:passwd@192.168.0.1:25060",
-          "index_prefix": "opensearch-logs"
+        "sink": {
+          "sink_id":"deadbeef-dead-4aa5-beef-deadbeef347d",
+          "sink_name": "logs-sink",
+          "sink_type": "opensearch",
+          "config": {
+            "url": "https://user:passwd@192.168.0.1:25060",
+            "index_prefix": "opensearch-logs"
+          }
         }
       }`
 
@@ -4123,6 +4125,57 @@ func TestDatabases_CreateLogsink(t *testing.T) {
 	require.Equal(t, want, log)
 }
 
+func TestDatabaseCreateLogsinkRequest_MarshalJSON(t *testing.T) {
+	// Test 1: rsyslog with TLS=false - should include TLS field
+	rsyslogReq := &DatabaseCreateLogsinkRequest{
+		Name: "test-rsyslog",
+		Type: "rsyslog",
+		Config: &DatabaseLogsinkConfig{
+			Server: "logs.example.com",
+			Port:   514,
+			TLS:    false,
+		},
+	}
+
+	data, err := json.Marshal(rsyslogReq)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"tls":false`)
+
+	// Test 2: rsyslog with TLS=true - should include TLS field
+	rsyslogReq.Config.TLS = true
+	data, err = json.Marshal(rsyslogReq)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"tls":true`)
+
+	// Test 3: opensearch with TLS=false - should NOT include TLS field
+	opensearchReq := &DatabaseCreateLogsinkRequest{
+		Name: "test-opensearch",
+		Type: "opensearch",
+		Config: &DatabaseLogsinkConfig{
+			URL: "https://example.com",
+			TLS: false,
+		},
+	}
+
+	data, err = json.Marshal(opensearchReq)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), `"tls"`)
+
+	// Test 4: elasticsearch with TLS=false - should NOT include TLS field
+	elasticsearchReq := &DatabaseCreateLogsinkRequest{
+		Name: "test-elasticsearch",
+		Type: "elasticsearch",
+		Config: &DatabaseLogsinkConfig{
+			URL: "https://example.com",
+			TLS: false,
+		},
+	}
+
+	data, err = json.Marshal(elasticsearchReq)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), `"tls"`)
+}
+
 func TestDatabases_GetLogsink(t *testing.T) {
 	setup()
 	defer teardown()
@@ -4143,12 +4196,14 @@ func TestDatabases_GetLogsink(t *testing.T) {
 	}
 
 	body := `{
-        "sink_id":"deadbeef-dead-4aa5-beef-deadbeef347d",
-        "sink_name": "logs-sink",
-        "sink_type": "opensearch",
-        "config": {
-          "url": "https://user:passwd@192.168.0.1:25060",
-          "index_prefix": "opensearch-logs"
+        "sink": {
+          "sink_id":"deadbeef-dead-4aa5-beef-deadbeef347d",
+          "sink_name": "logs-sink",
+          "sink_type": "opensearch",
+          "config": {
+            "url": "https://user:passwd@192.168.0.1:25060",
+            "index_prefix": "opensearch-logs"
+          }
         }
       }`
 


### PR DESCRIPTION
## Summary

As part of adding database logsink related resources to our Terraform provider I discovered and fixed the following bugs in godo:

1. **API Response Parsing Issue**: `CreateLogsink` and `GetLogsink` were expecting direct responses but the API returns data wrapped in a `"sink"` field
2. **TLS Field Marshaling Issue**: Rsyslog logsinks require the `tls` field to always be present in JSON, but Go's `omitempty` tag was omitting it when `false`

## Bug and Change Details

### Issue 1: API Response Wrapper Missing for Logsink Operations

**The Bug:**
Both `CreateLogsink` and `GetLogsink` were not using root wrapper structs, making them inconsistent with all other database operations:

The DigitalOcean API returns responses wrapped in a `"sink"` field:
```json
{
  "sink": {
    "sink_id": "...",
    "sink_name": "...",
    "config": {}
  }
}
```

But the code was expecting a direct response without the wrapper.

**The Fix (`databases.go`):**
- Added `databaseLogsinkRoot` struct with `Sink *DatabaseLogsink` field
- Updated `CreateLogsink` to use `databaseLogsinkRoot` instead of `DatabaseLogsink` directly
- Updated `GetLogsink` to use `databaseLogsinkRoot` and return `root.Sink` instead of `root`
- This aligns both operations with the established pattern used by all other database operations

**Test Updates (`databases_test.go`):**
- Fixed `TestDatabases_CreateLogsink` mock response to include `"sink"` wrapper
- Fixed `TestDatabases_GetLogsink` mock response to include `"sink"` wrapper

### Issue 2: TLS Field Incorrectly Omitted for Rsyslog Logsinks

**The Bug:**
The rsyslog logsink API requires the `tls` field to always be present in JSON requests, even when set to `false`. However, the shared `DatabaseLogsinkConfig` struct used `omitempty` on the TLS field, which caused Go to omit the field when `false`. This broke rsyslog logsink creation. Other sink types (opensearch, elasticsearch) don't support the TLS field at all, so it must be omitted for them.

**The Fix (`databases.go`):**
- Added custom `MarshalJSON` method for `DatabaseCreateLogsinkRequest`
- For rsyslog sink type: Uses a custom config struct with `TLS bool json:"tls"` (no omitempty) to ensure the field is always present
- For other sink types: Uses default marshaling behavior (preserves omitempty) to exclude the TLS field
- Added required `encoding/json` import

**Test Updates (`databases_test.go`):**
- Added comprehensive `TestDatabaseCreateLogsinkRequest_MarshalJSON` test covering:
  - Rsyslog with TLS=false (verifies field is present with value `false`)
  - Rsyslog with TLS=true (verifies field is present with value `true`)
  - Opensearch/elasticsearch with TLS=false (verifies field is omitted)

## Verification

This fix has been validated with real API calls in the terraform-provider-digitalocean where all acceptance tests for the new logsink related resources now pass when using this updated version of godo:
- Basic creation and management
- TLS configuration
- Custom format configuration
- Update operations
- Import functionality
- Comprehensive validation scenarios